### PR TITLE
Use Vite environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_SUPABASE_URL=your-supabase-url
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+VITE_STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.env.*
+!.env.example

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "vite --mode development",
+    "build": "vite build --mode production",
     "preview": "vite preview",
     "lint": "eslint \"src*.{js,jsx}\" --quiet"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ import PremiumCancelPage from '@/pages/PremiumCancelPage';
 import { loadStripe } from '@stripe/stripe-js';
 import { Elements } from '@stripe/react-stripe-js';
 
-const STRIPE_PUBLISHABLE_KEY = "pk_test_51Rgdk6CiatFVYXDzOHrSEdPadEIP5z0fNNOQMNYwotUidKnl8uMwPSTVtadcP62PMqcbmeWaNoRECwoGZ6QggIPN00bwtLhz6U";
+const STRIPE_PUBLISHABLE_KEY = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY;
 const stripePromise = loadStripe(STRIPE_PUBLISHABLE_KEY);
 
 function App() {

--- a/src/lib/customSupabaseClient.js
+++ b/src/lib/customSupabaseClient.js
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://thceupkmlmusckmveele.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRoY2V1cGttbG11c2NrbXZlZWxlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDgxMDY0NDgsImV4cCI6MjA2MzY4MjQ0OH0.Zrb8fGdBm6M8gO-fYtOd-mMO7n3X7OYFhdZk7Px1DQQ';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://thceupkmlmusckmveele.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRoY2V1cGttbG11c2NrbXZlZWxlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDgxMDY0NDgsImV4cCI6MjA2MzY4MjQ0OH0.Zrb8fGdBm6M8gO-fYtOd-mMO7n3X7OYFhdZk7Px1DQQ';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- switch Supabase and Stripe keys to use `import.meta.env`
- add `.env.example`
- ignore `.env` files and build artifacts
- load env-specific variables via explicit Vite `--mode`

## Testing
- `npm run build`
- `npm run lint` *(fails: No files matching the pattern)*

------
https://chatgpt.com/codex/tasks/task_e_68660d0617788325a1484c575ccfe1ce