### PR TITLE
Add Docker build and compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # rfx-audit-v3
+
+This repository contains the code for the RedFox Audit Core Vite application.
+
+## Running with Docker
+
+A `Dockerfile` is provided to build the production assets and serve them with
+`nginx`. A matching `docker-compose.yml` exposes the container on a configurable
+port (default `8080`).
+
+### Local usage
+
+```bash
+# build and run using docker compose
+docker compose up -d
+# change the exposed port
+PORT=3000 docker compose up -d
+```
+
+### Deploying with Portainer
+
+1. Open Portainer and create a new stack.
+2. Paste the contents of `docker-compose.yml` into the stack editor.
+3. (Optional) Set the `PORT` environment variable to change the published port.
+4. Deploy the stack and access the app via `http://<host>:<PORT>`.
+
+The image is built from source at deploy time. For faster deploys you can
+pre-build the image locally and push it to a registry, then update the Compose
+file to use that image instead of the build context.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "${PORT:-8080}:80"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add `.gitignore`
- add Dockerfile for building the Vite app and serving via nginx
- add docker-compose with configurable port
- document Docker/Portainer usage in README

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68660d0adc048325a8dbbcb2c08fb5f1