### PR TITLE
Add n8n-proxy function example and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ A typical deployment workflow is:
 2. Push the image to your registry.
 3. Use Portainer or another orchestrator (Docker Compose, Kubernetes) to run the container in production.
 
+## Supabase Edge Function Deployment
+
+This repo contains a sample function under `functions/n8n-proxy` that forwards
+requests to an n8n webhook.
+
+1. Install the [Supabase CLI](https://supabase.com/docs/guides/cli).
+2. Authenticate with `supabase login` and ensure your project is initialized.
+3. Deploy the function:
+
+   ```bash
+   supabase functions deploy n8n-proxy
+   supabase secrets set N8N_WEBHOOK_URL=<your-n8n-url>
+   ```
+
+After deployment you can invoke it from the client:
+
+```javascript
+const { data, error } = await supabase.functions.invoke('n8n-proxy')
+```
+
 ---
 
 For additional customization (like scanning engines or API key management), see the Settings page inside the application.

--- a/functions/n8n-proxy/index.js
+++ b/functions/n8n-proxy/index.js
@@ -1,0 +1,21 @@
+import { serve } from 'https://deno.land/std@0.192.0/http/server.ts'
+
+console.log('n8n-proxy function started')
+
+serve(async (req) => {
+  const n8nUrl = Deno.env.get('N8N_WEBHOOK_URL')
+  if (!n8nUrl) {
+    return new Response('Missing N8N_WEBHOOK_URL', { status: 500 })
+  }
+
+  const res = await fetch(n8nUrl, {
+    method: req.method,
+    headers: { 'Content-Type': 'application/json' },
+    body: req.method === 'GET' ? undefined : await req.text()
+  })
+
+  return new Response(await res.text(), {
+    status: res.status,
+    headers: { 'Content-Type': 'application/json' }
+  })
+})

--- a/functions/n8n-proxy/index.ts
+++ b/functions/n8n-proxy/index.ts
@@ -1,0 +1,21 @@
+import { serve } from 'https://deno.land/std@0.192.0/http/server.ts'
+
+console.log('n8n-proxy function started')
+
+serve(async (req: Request) => {
+  const n8nUrl = Deno.env.get('N8N_WEBHOOK_URL')
+  if (!n8nUrl) {
+    return new Response('Missing N8N_WEBHOOK_URL', { status: 500 })
+  }
+
+  const res = await fetch(n8nUrl, {
+    method: req.method,
+    headers: { 'Content-Type': 'application/json' },
+    body: req.method === 'GET' ? undefined : await req.text()
+  })
+
+  return new Response(await res.text(), {
+    status: res.status,
+    headers: { 'Content-Type': 'application/json' }
+  })
+})


### PR DESCRIPTION
## Summary
- add example Supabase edge function at `functions/n8n-proxy`
- document how to deploy `n8n-proxy` via the Supabase CLI

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866a0a35a948325a7f1f608aecb0d50